### PR TITLE
Allow building on RISCV64 platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm" OR ${CMAKE_SYSTEM_PROCESSOR} MATCHES 
     set(IS_ARM ON)
     # ARM compilation not yet implemented!
     set(WITH_ISAL OFF)
+elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "riscv64")
+    set(WITH_ISAL OFF)
+    set(WITH_RPMALLOC OFF)
 else()
     set(IS_ARM OFF)
 endif()
@@ -47,7 +50,7 @@ add_compile_options(
     "$<$<AND:$<COMPILE_LANG_AND_ID:CXX,Clang,GNU>,$<PLATFORM_ID:Windows>>:-Wa,-mbig-obj>"
 )
 
-if(NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm" AND NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch")
+if(NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm" AND NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch" AND NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "riscv64")
     add_compile_options("$<$<COMPILE_LANG_AND_ID:CXX,Clang,GNU>:-fcf-protection=full>")
 endif()
 

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -8,7 +8,12 @@ target_link_libraries(bitpatternstats PRIVATE cxxopts indexed_bzip2_parallel)
 
 add_executable(rapidgzip)
 target_sources(rapidgzip PRIVATE ${CMAKE_CURRENT_LIST_DIR}/rapidgzip.cpp)
-target_link_libraries(rapidgzip PRIVATE cxxopts librapidgzip rpmalloc)
+if(WITH_RPMALLOC)
+    target_link_libraries(rapidgzip PRIVATE cxxopts librapidgzip rpmalloc)
+else()
+    target_link_libraries(rapidgzip PRIVATE cxxopts librapidgzip)
+endif()
+
 if(WITH_RPMALLOC)
     target_compile_definitions(rapidgzip PRIVATE WITH_RPMALLOC)
 endif()


### PR DESCRIPTION
I wanted to build the `rapidgzip` tool on RISCV64 based Orange Pi RV2. The OS is based on Ubuntu Noble. It looks like I need to do

1. disable ISAL
2. disable rpmalloc

I made changes to allow disabling rpmalloc. Also, we need to disable the hardening option `fcf-protection` on this platform as well.

After these changes I can do `mkdir build; cd build; cmake ..; make -j 8 rapidgzip` and get the program after a few minutes. I used cxxopts 3.3.1 and zlib 1.3.1. It is maybe 4x the performance of the normal `gzip` on this board.

Note I have never edited CMakeLists.txt before, there may be some better ways to do this.