### PR TITLE
Make countNewlines inline and retain nodiscard to avoid ' multiple de…

### DIFF
--- a/src/core/common.hpp
+++ b/src/core/common.hpp
@@ -578,7 +578,7 @@ loadUnaligned( const void* data )
 }
 
 
-[[nodiscard]] size_t
+[[nodiscard]] inline size_t
 countNewlines( const std::string_view& view )
 {
     return std::count( view.begin(), view.end(), '\n' );


### PR DESCRIPTION
…finition' linking errors

While linking [sortmerna](https://github.com/sortmerna) against indexed_bzip2 library the following was thrown:
```
...
/usr/bin/ld: src/sortmerna/CMakeFiles/sortmerna.dir/Release/main.cpp.o: in function `rapidgzip::countNewlines(std::basic_string_view<char, std::char_traits<char> > const&)':
main.cpp:(.text+0xcd0): multiple definition of `rapidgzip::countNewlines(std::basic_string_view<char, std::char_traits<char> > const&)'; src/sortmerna/CMakeFiles/smr_objs.dir/Release/cmd.cpp.o:cmd.cpp:(.text+0xd50): first defined here
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
...
```